### PR TITLE
Changing ftrackData keys to match ftrack entities

### DIFF
--- a/pyblish_ftrack/plugins/conform_ftrack_component.py
+++ b/pyblish_ftrack/plugins/conform_ftrack_component.py
@@ -37,4 +37,4 @@ class FtrackUploadComponent(pyblish.api.Conformer):
                 self.log.info('No versionID found in context')
 
         else:
-            self.log.warning('No published flipbook found!')
+            self.log.warning('No published component found!')

--- a/pyblish_ftrack/plugins/conform_ftrack_createVersion.py
+++ b/pyblish_ftrack/plugins/conform_ftrack_createVersion.py
@@ -24,9 +24,9 @@ class FtrackCreateVersion(pyblish.api.Conformer):
                 self.log.info('CREATING VERSION')
                 versionNumber = instance.context.data('ftrackData')['version']['number']
 
-                taskid = instance.context.data('ftrackData')['task']['id']
+                taskid = instance.context.data('ftrackData')['Task']['id']
 
-                asset = ftrack.Asset(id=instance.context.data('ftrackData')['asset']['id'])
+                asset = ftrack.Asset(id=instance.context.data('ftrackData')['Asset']['id'])
                 self.log.info('Using ftrack asset {}'.format(asset.getName()))
 
                 version = asset.createVersion(comment='', taskid=taskid)

--- a/pyblish_ftrack/plugins/select_ftrack.py
+++ b/pyblish_ftrack/plugins/select_ftrack.py
@@ -9,6 +9,7 @@ import pyblish_ftrack_utils
 
 import pyblish.api
 
+
 @pyblish.api.log
 class CollectFtrack(pyblish.api.Selector):
     """Collects ftrack data from FTRACK_CONNECT_EVENT"""
@@ -28,14 +29,13 @@ class CollectFtrack(pyblish.api.Selector):
         taskid = decodedEventData.get('selection')[0]['entityId']
         ftrackData = pyblish_ftrack_utils.getData(taskid)
 
-
         # Get ftrack Asset
         task = ftrack.Task(taskid)
 
-        shot = ftrack.Shot(id=ftrackData['shot']['id'])
+        shot = ftrack.Shot(id=ftrackData['Shot']['id'])
 
-        assetType = ftrackData['task']['code']
-        assetName = ftrackData['task']['type']
+        assetType = ftrackData['Task']['code']
+        assetName = ftrackData['Task']['type']
 
         assets = task.getAssets(assetTypes=[assetType])
 
@@ -54,7 +54,7 @@ class CollectFtrack(pyblish.api.Selector):
 
         self.log.info('Using ftrack asset {}'.format(asset.getName()))
 
-        ftrackData['asset'] = {'id': asset.getId(),
+        ftrackData['Asset'] = {'id': asset.getId(),
                                'name': asset.getName()
                                }
         # Get version number
@@ -65,10 +65,9 @@ class CollectFtrack(pyblish.api.Selector):
             try:
                 prefix, version = pyblish_ftrack_utils.version_get(filename, 'v')
                 ftrackData['version'] = {'number': int(version)}
-            except:
+            except ValueError:
                 self.log.warning('Cannot find version string in filename.')
-                return
-
+                return None
 
         self.log.info('Publish Version: {}'.format(ftrackData['version']['number']))
 

--- a/pyblish_ftrack/plugins/validate_ftrack_version.py
+++ b/pyblish_ftrack/plugins/validate_ftrack_version.py
@@ -21,7 +21,7 @@ class ValidateFtrackVersion(pyblish.api.Validator):
 
             versionNumber = instance.context.data('ftrackData')['version']['number']
 
-            asset = ftrack.Asset(id=instance.context.data('ftrackData')['asset']['id'])
+            asset = ftrack.Asset(id=instance.context.data('ftrackData')['Asset']['id'])
 
             version = None
             for v in asset.getVersions():

--- a/pyblish_ftrack/pyblish_ftrack_utils.py
+++ b/pyblish_ftrack/pyblish_ftrack_utils.py
@@ -24,20 +24,21 @@ task_codes = {
 def getData(taskid):
     try:
         task = ftrack.Task(id=taskid)
-    except:
+    except ValueError:
         task = None
 
     parents = task.getParents()
     project = ftrack.Project(task.get('showid'))
     taskType = task.getType().getName()
+    entityType = task.getObjectType()
 
     ctx = {
-        'project': {
+        'Project': {
                 'name': project.get('fullname'),
                 'code': project.get('name'),
                 'id': task.get('showid')
         },
-        'task': {
+        entityType: {
                 'type': taskType,
                 'name': task.getName(),
                 'id': task.getId(),
@@ -48,14 +49,16 @@ def getData(taskid):
     for parent in parents:
         tempdic = {}
         if parent.get('entityType') == 'task' and parent.getObjectType():
+            print parent
             objectType = parent.getObjectType()
             tempdic['name'] = parent.getName()
             tempdic['description'] = parent.getDescription()
             tempdic['id'] = parent.getId()
             if objectType == 'Asset Build':
                 tempdic['type'] = parent.getType().get('name')
-                objectType = 'asset_build'
-            ctx[objectType.lower()] = tempdic
+                objectType = objectType.replace(' ', '_')
+
+            ctx[objectType] = tempdic
 
     return ctx
 


### PR DESCRIPTION
changed keys in ftrackData to exactly match ftrack entities names. Previously they were converted to lowercase, but keeping them same as in ftrack will be more future proof. This might break some dependencies in other extensions that are using ftrackData. Getting data from all keys will need to be changed to match the new names: `task`-> `Task`, `shot` -> `Shot`, `asset_build` -> `Asset Build`, etc.
