### PR TITLE
Make asset operate on instance

### DIFF
--- a/pyblish_ftrack/plugins/collect_ftrack_data.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_data.py
@@ -1,13 +1,13 @@
 import os
 import json
 import base64
-import sys
 import ftrack
 import pyblish.api
 
 
 @pyblish.api.log
 class CollectFtrackData(pyblish.api.Selector):
+
     """Collects ftrack data from FTRACK_CONNECT_EVENT
         Arguments:
             version (int): version number of the publish
@@ -59,16 +59,16 @@ class CollectFtrackData(pyblish.api.Selector):
 
         ctx = {
             'Project': {
-                    'name': project.get('fullname'),
-                    'code': project.get('name'),
-                    'id': task.get('showid'),
-                    'root': project.getRoot(),
+                'name': project.get('fullname'),
+                'code': project.get('name'),
+                'id': task.get('showid'),
+                'root': project.getRoot(),
             },
             entityType: {
-                    'type': taskType,
-                    'name': task.getName(),
-                    'id': task.getId(),
-                    'code': task_codes.get(taskType, None)
+                'type': taskType,
+                'name': task.getName(),
+                'id': task.getId(),
+                'code': task_codes.get(taskType, None)
             }
         }
 

--- a/pyblish_ftrack/plugins/conform_ftrack.py
+++ b/pyblish_ftrack/plugins/conform_ftrack.py
@@ -25,9 +25,9 @@ class ConformFtrack(pyblish.api.Conformer):
             return
 
         ftrack_data = instance.context.data('ftrackData')
-
+        asset_version = instance.data('ftrackAssetVersion')
         # creating components
-        version = ftrack.AssetVersion(ftrack_data['AssetVersion']['id'])
+        version = ftrack.AssetVersion(asset_version['id'])
         components = instance.data('ftrackComponents')
         for component_name in instance.data('ftrackComponents'):
 

--- a/pyblish_ftrack/plugins/conform_ftrack.py
+++ b/pyblish_ftrack/plugins/conform_ftrack.py
@@ -1,10 +1,10 @@
 import pyblish.api
-
 import ftrack
 
 
 @pyblish.api.log
 class ConformFtrack(pyblish.api.Conformer):
+
     """ Creating Componenets in Ftrack.
     """
 
@@ -24,7 +24,6 @@ class ConformFtrack(pyblish.api.Conformer):
                            Skipping this instance')
             return
 
-        ftrack_data = instance.context.data('ftrackData')
         asset_version = instance.data('ftrackAssetVersion')
         # creating components
         version = ftrack.AssetVersion(asset_version['id'])

--- a/pyblish_ftrack/plugins/extract_ftrack.py
+++ b/pyblish_ftrack/plugins/extract_ftrack.py
@@ -1,10 +1,10 @@
 import pyblish.api
-
 import ftrack
 
 
 @pyblish.api.log
 class ExtractFtrack(pyblish.api.Extractor):
+
     """ Creating any Asset or AssetVersion in Ftrack.
     """
 

--- a/pyblish_ftrack/plugins/extract_ftrack.py
+++ b/pyblish_ftrack/plugins/extract_ftrack.py
@@ -10,10 +10,10 @@ class ExtractFtrack(pyblish.api.Extractor):
 
     label = 'Ftrack'
 
-    def process(self, instance):
+    def process(self, instance, context):
 
         # skipping instance if ftrackData isn't present
-        if not instance.context.has_data('ftrackData'):
+        if not context.has_data('ftrackData'):
             self.log.info('No ftrackData present. Skipping this instance')
             return
 
@@ -22,21 +22,21 @@ class ExtractFtrack(pyblish.api.Extractor):
             self.log.info('No ftrackComponents found. Skipping this instance')
             return
 
-        ftrack_data = instance.context.data('ftrackData').copy()
+        ftrack_data = context.data('ftrackData').copy()
         task = ftrack.Task(ftrack_data['Task']['id'])
         parent = task.getParent()
 
         # creating asset
-        if instance.context.data('ftrackAssetCreate'):
+        if instance.data('ftrackAssetCreate'):
             asset = None
 
             # creating asset from ftrackAssetName
-            if instance.context.has_data('ftrackAssetName'):
+            if instance.has_data('ftrackAssetName'):
 
-                asset_name = instance.context.data('ftrackAssetName')
+                asset_name = instance.data('ftrackAssetName')
 
-                if instance.context.has_data('ftrackAssetType'):
-                    asset_type = instance.context.data('ftrackAssetType')
+                if instance.has_data('ftrackAssetType'):
+                    asset_type = instance.data('ftrackAssetType')
                 else:
                     asset_type = ftrack_data['Task']['code']
 
@@ -57,29 +57,32 @@ class ExtractFtrack(pyblish.api.Extractor):
                 self.log.info(msg)
 
             # adding asset to ftrack data
-            ftrack_data['Asset'] = {'id': asset.getId(),
-                                    'name': asset.getName()}
+            asset_data = {'id': asset.getId(),
+                          'name': asset.getName()}
+            create_version = True
 
         # creating version
         version = None
-        if instance.context.data('ftrackAssetVersionCreate'):
-            asset = ftrack.Asset(ftrack_data['Asset']['id'])
+        if instance.data('ftrackAssetVersionCreate') or create_version:
+            asset_data = instance.data('ftrackAsset')
+            asset = ftrack.Asset(asset_data['id'])
             taskid = ftrack_data['Task']['id']
-            version_number = int(instance.context.data('version'))
+            version_number = int(context.data('version'))
 
             version = asset.createVersion(comment='', taskid=taskid)
             version.set('version', value=version_number)
-            ftrack_data['AssetVersion'] = {'id': version.getId(),
-                                           'number': version_number}
+            asset_version = {'id': version.getId(), 'number': version_number}
+            instance.set_data('ftrackAssetVersion', value=asset_version)
             version.publish()
 
             self.log.info('Creating new asset version by %s.' % version_number)
         else:
             # using existing version
-            version = ftrack.AssetVersion(ftrack_data['AssetVersion']['id'])
+            asset_version = instance.data('ftrackAssetVersion')
+            version = ftrack.AssetVersion(asset_version['id'])
 
-        # adding asset to ftrack data
-        ftrack_data['AssetVersion'] = {'id': version.getId()}
+        # adding asset version to ftrack data
+        instance.set_data('ftrackAssetVersion', value=asset_version)
 
         # setting ftrackData
-        instance.context.set_data('ftrackData', value=ftrack_data)
+        context.set_data('ftrackData', value=ftrack_data)

--- a/pyblish_ftrack/plugins/extract_ftrack.py
+++ b/pyblish_ftrack/plugins/extract_ftrack.py
@@ -26,7 +26,6 @@ class ExtractFtrack(pyblish.api.Extractor):
         task = ftrack.Task(ftrack_data['Task']['id'])
         parent = task.getParent()
         asset_data = None
-        create_version = False
         # creating asset
         if instance.data('ftrackAssetCreate'):
             asset = None
@@ -75,7 +74,7 @@ class ExtractFtrack(pyblish.api.Extractor):
                 version = asset.createVersion(comment='', taskid=taskid)
                 version.set('version', value=version_number)
             except:
-                version = self.GetVersionByNmber(asset, version_number)
+                version = self.GetVersionByNumber(asset, version_number)
 
             asset_version = {'id': version.getId(), 'number': version_number}
             instance.set_data('ftrackAssetVersion', value=asset_version)
@@ -90,10 +89,7 @@ class ExtractFtrack(pyblish.api.Extractor):
         # adding asset version to ftrack data
         instance.set_data('ftrackAssetVersion', value=asset_version)
 
-        # setting ftrackData
-        context.set_data('ftrackData', value=ftrack_data)
-
-    def GetVersionByNmber(self, asset, number):
+    def GetVersionByNumber(self, asset, number):
         for version in asset.getVersions():
             try:
                 if version.getVersion() == int(number):

--- a/pyblish_ftrack/plugins/extract_ftrack.py
+++ b/pyblish_ftrack/plugins/extract_ftrack.py
@@ -25,7 +25,8 @@ class ExtractFtrack(pyblish.api.Extractor):
         ftrack_data = context.data('ftrackData').copy()
         task = ftrack.Task(ftrack_data['Task']['id'])
         parent = task.getParent()
-
+        asset_data = None
+        create_version = False
         # creating asset
         if instance.data('ftrackAssetCreate'):
             asset = None
@@ -61,10 +62,11 @@ class ExtractFtrack(pyblish.api.Extractor):
                           'name': asset.getName()}
             create_version = True
 
+        if not asset_data:
+            asset_data = instance.data('ftrackAsset')
         # creating version
         version = None
         if instance.data('ftrackAssetVersionCreate') or create_version:
-            asset_data = instance.data('ftrackAsset')
             asset = ftrack.Asset(asset_data['id'])
             taskid = ftrack_data['Task']['id']
             version_number = int(context.data('version'))

--- a/pyblish_ftrack/plugins/validate_ftrack.py
+++ b/pyblish_ftrack/plugins/validate_ftrack.py
@@ -35,7 +35,6 @@ class ValidateFtrack(pyblish.api.Validator):
         else:
             asset_type = ftrack_data['Task']['code']
 
-        # TODO: Make sure we're looking for the correct asset type.
         assets = task.getAssets(assetTypes=[asset_type])
 
         if len(assets) == 0:
@@ -86,7 +85,6 @@ class ValidateFtrack(pyblish.api.Validator):
         # if we are creating a new asset,
         # then we don't need to validate the rest
         if create_asset:
-            context.set_data('ftrackData', value=ftrack_data)
             return
 
         # checking version
@@ -120,7 +118,6 @@ class ValidateFtrack(pyblish.api.Validator):
         # if we are creating a new asset version,
         # then we don't need to validate the rest
         if create_version:
-            context.set_data('ftrackData', value=ftrack_data)
             return
 
         # checking components
@@ -143,6 +140,3 @@ class ValidateFtrack(pyblish.api.Validator):
                                delete it in the webUI first'
                         assert online_c.getName() not in (
                             'ftrackreview-mp4', 'ftrackreview-webm'), msg
-
-        # setting ftrackData
-        context.set_data('ftrackData', value=ftrack_data)

--- a/pyblish_ftrack/plugins/validate_ftrack.py
+++ b/pyblish_ftrack/plugins/validate_ftrack.py
@@ -4,6 +4,7 @@ import ftrack
 
 @pyblish.api.log
 class ValidateFtrack(pyblish.api.Validator):
+
     """ Validate the existence of Asset, AssetVersion and Components.
     """
 
@@ -131,7 +132,8 @@ class ValidateFtrack(pyblish.api.Validator):
                         msg = 'Reviewable component already exists in the\
                                version. To replace it\
                                delete it in the webUI first'
-                        assert online_c.getName() not in ('ftrackreview-mp4', 'ftrackreview-webm'), msg
+                        assert online_c.getName() not in (
+                            'ftrackreview-mp4', 'ftrackreview-webm'), msg
 
         # setting ftrackData
         context.set_data('ftrackData', value=ftrack_data)

--- a/pyblish_ftrack/plugins/validate_ftrack.py
+++ b/pyblish_ftrack/plugins/validate_ftrack.py
@@ -50,15 +50,20 @@ class ValidateFtrack(pyblish.api.Validator):
         else:
             # if only one asset exists, then we'll use that asset
             msg = "Can't compute asset. Multiple assets on shot:"
-            for a in assets:
-                msg += "\n\n%s" % a
-            assert len(assets) == 1, msg
-
-            for a in assets:
-                asset = a
-                create_asset = False
-
-                self.log.info('Found existing asset by default.')
+            if len(assets) == 1:
+                for a in assets:
+                    print a
+                    asset = a
+                    create_asset = False
+                    self.log.info('Found existing asset by default.')
+            else:
+                asset_name = ftrack_data['Task']['type']
+                for a in assets:
+                    msg += "\n\n%s" % a
+                    if asset_name.lower() == a.getName().lower():
+                        asset = a
+            # TODO: fix singel asset auto selection
+            assert asset, msg
 
         # adding asset to ftrack data
         if asset:


### PR DESCRIPTION
This is quite extensive change that is not backwards compatible with extensions relying on ftrack data it provides. Hence for example pyblish-deadline would need a little tweak to work properly.

Behaviour should stay the same as previously, so no change to existing custom selector needs to be done for it to work in a basic sense,.

It was however necessary to add a few checks when creating new version to prevent duplication errors.

We've took the plunge and tested it in production for couple of day and no issues have popped up, so I think it's ready
