### PR TITLE
File Type Overwriting

### DIFF
--- a/pyblish_ftrack/plugins/integrate_ftrack_api.py
+++ b/pyblish_ftrack/plugins/integrate_ftrack_api.py
@@ -161,10 +161,18 @@ class PyblishFtrackIntegrateFtrackApi(pyblish.api.InstancePlugin):
                     collection = clique.parse(data["component_path"])
                 except ValueError:
                     # Assume its a single file
+                    # Changing file type
+                    component_entity["file_type"] = os.path.splitext(
+                        data["component_path"]
+                    )[-1]
+
                     origin_location.add_component(
                         component_entity, data["component_path"]
                     )
                 else:
+                    # Changing file type
+                    component_entity["file_type"] = collection.format("{tail}")
+
                     # Create member components for sequence.
                     for member_path in collection:
 

--- a/pyblish_ftrack/plugins/integrate_ftrack_api.py
+++ b/pyblish_ftrack/plugins/integrate_ftrack_api.py
@@ -162,9 +162,8 @@ class PyblishFtrackIntegrateFtrackApi(pyblish.api.InstancePlugin):
                 except ValueError:
                     # Assume its a single file
                     # Changing file type
-                    component_entity["file_type"] = os.path.splitext(
-                        data["component_path"]
-                    )[-1]
+                    name, ext = os.path.splitext(data["component_path"])
+                    component_entity["file_type"] = ext
 
                     origin_location.add_component(
                         component_entity, data["component_path"]


### PR DESCRIPTION
If a component is overwritten with a different file extension, the original extension is preserved. This will allow for changing the file extension when overwriting the component.