### PR TITLE
Prevent plugins failure when FTRACK_TASKID is not present.

### DIFF
--- a/pyblish_ftrack/plugins/collect_ftrack_api.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_api.py
@@ -2,7 +2,7 @@ import os
 import json
 import base64
 
-import ftrack_api
+from ftrack_connect.session import get_shared_session
 import pyblish.api
 
 
@@ -15,7 +15,7 @@ class PyblishFtrackCollectFtrackApi(pyblish.api.ContextPlugin):
     def process(self, context):
 
         # Collect session
-        session = ftrack_api.Session()
+        session = get_shared_session()
         context.data["ftrackSession"] = session
 
         # Collect task

--- a/pyblish_ftrack/plugins/collect_ftrack_api.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_api.py
@@ -29,6 +29,6 @@ class PyblishFtrackCollectFtrackApi(pyblish.api.ContextPlugin):
 
             taskid = decodedEventData.get("selection")[0]["entityId"]
         except:
-            taskid = os.environ["FTRACK_TASKID"]
+            taskid = os.environ.get("FTRACK_TASKID", "")
 
         context.data["ftrackTask"] = session.get("Task", taskid)

--- a/pyblish_ftrack/plugins/collect_ftrack_api.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_api.py
@@ -2,7 +2,7 @@ import os
 import json
 import base64
 
-from ftrack_connect.session import get_shared_session
+import ftrack_api
 import pyblish.api
 
 
@@ -15,7 +15,7 @@ class PyblishFtrackCollectFtrackApi(pyblish.api.ContextPlugin):
     def process(self, context):
 
         # Collect session
-        session = get_shared_session()
+        session = ftrack_api.Session()
         context.data["ftrackSession"] = session
 
         # Collect task

--- a/pyblish_ftrack/plugins/collect_ftrack_data.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_data.py
@@ -36,14 +36,15 @@ class CollectFtrackData(pyblish.api.Selector):
 
             taskid = decodedEventData.get('selection')[0]['entityId']
         except:
-            taskid = os.environ['FTRACK_TASKID']
+            taskid = os.environ.get('FTRACK_TASKID', '')
 
-        ftrack_data = self.get_data(taskid)
+        if taskid:
+            ftrack_data = self.get_data(taskid)
 
-        # set ftrack data
-        context.set_data('ftrackData', value=ftrack_data)
+            # set ftrack data
+            context.set_data('ftrackData', value=ftrack_data)
 
-        self.log.info('Found ftrack data: \n\n%s' % ftrack_data)
+            self.log.info('Found ftrack data: \n\n%s' % ftrack_data)
 
     def get_data(self, taskid):
 


### PR DESCRIPTION
This PR is an effort to support NukeStudio/Hiero where you can launch the application outside of any project and task.

Equally there was a crash on NukeStudio when getting the ftrack_api session, which is getting prevented by getting the shared session from ftrack-connect. This should also speed up the plugin, as we don't need to generate a new session on each collection.