### PR TITLE
Thumbnail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ for data in instance.data["ftrackComponentsList"]:
     print data["component"]
 ```
 
+#### Thumbnail
+
+You can set the thumbnail of the AssetVersion by adding a component and setting the ```thumbnail``` data member:
+
+```python
+{
+  "component_data": {
+    "name": "thumbnail"
+  },
+  "component_path": "path/to/thumbnail/image",
+  "component_location": session.query(
+    "Location where name is \"ftrack.server\""
+  ).one(),
+  "thumbnail": True
+}
+```
+
 ### Old API
 
 To succesfully publish an instance to ftrack using this extension you need to append a few data members to the instance you want to publish.

--- a/pyblish_ftrack/plugins/integrate_ftrack_api.py
+++ b/pyblish_ftrack/plugins/integrate_ftrack_api.py
@@ -269,6 +269,10 @@ class PyblishFtrackIntegrateFtrackApi(pyblish.api.InstancePlugin):
             existing_component_metadata.update(component_metadata)
             component_entity["metadata"] = existing_component_metadata
 
+            # Setting assetversion thumbnail
+            if data.get("thumbnail", False):
+                assetversion_entity["thumbnail_id"] = component_entity["id"]
+
             # Inform user about no changes to the database.
             if component_entity and not component_overwrite:
                 data["component"] = component_entity


### PR DESCRIPTION
**Motivation**

To add a thumbnail when publishing.

**Implementation**

To set the thumbnail you need to create a component and set the data member ```thumbnail``` to ```True```, which causes the integrator to set the AssetVersions thumbnail id to the component.
For this reason its important that the location is ```ftrack.server```.

There are convenience methods for creating a thumbnail; http://ftrack-python-api.rtd.ftrack.com/en/latest/example/thumbnail.html?highlight=create_thumbnail, but it does the same as described above.
The reason for not using this convenience method was because I couldn't figure out a logical way of adding to the components list. The current solution of having a data member ```thumbnail``` seemed simple to me.
I'm open to suggestions about how to use the convenience method.