### PR TITLE
Use Unique Plugin Labels

### DIFF
--- a/pyblish_ftrack/plugins/collect_context_version.py
+++ b/pyblish_ftrack/plugins/collect_context_version.py
@@ -5,7 +5,7 @@ import pyblish.api
 
 
 @pyblish.api.log
-class SelectContextVersion(pyblish.api.Selector):
+class CollectContextVersion(pyblish.api.Selector):
     """Finds version in the filename or passes the one found in the context
         Arguments:
         version (int, optional): version number of the publish

--- a/pyblish_ftrack/plugins/collect_context_version.py
+++ b/pyblish_ftrack/plugins/collect_context_version.py
@@ -1,9 +1,5 @@
 import os
-import sys
 import re
-
-# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-# import pyblish_ftrack_utils
 
 import pyblish.api
 

--- a/pyblish_ftrack/plugins/collect_ftrack_api.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_api.py
@@ -10,7 +10,7 @@ class CollectFtrackApi(pyblish.api.ContextPlugin):
     """ Collects an ftrack session and the current task id. """
 
     order = pyblish.api.CollectorOrder
-    label = "Ftrack"
+    label = "Collect Ftrack Api"
 
     def process(self, context):
 

--- a/pyblish_ftrack/plugins/collect_ftrack_api.py
+++ b/pyblish_ftrack/plugins/collect_ftrack_api.py
@@ -6,7 +6,7 @@ import ftrack_api
 import pyblish.api
 
 
-class PyblishFtrackCollectFtrackApi(pyblish.api.ContextPlugin):
+class CollectFtrackApi(pyblish.api.ContextPlugin):
     """ Collects an ftrack session and the current task id. """
 
     order = pyblish.api.CollectorOrder

--- a/pyblish_ftrack/plugins/conform_ftrack.py
+++ b/pyblish_ftrack/plugins/conform_ftrack.py
@@ -2,7 +2,7 @@ import pyblish.api
 import ftrack
 
 
-class IntegrateFtrack(pyblish.api.InstancePlugin):
+class ConformFtrack(pyblish.api.InstancePlugin):
     """ Creating components in Ftrack. """
 
     order = pyblish.api.IntegratorOrder + 0.4

--- a/pyblish_ftrack/plugins/conform_ftrack.py
+++ b/pyblish_ftrack/plugins/conform_ftrack.py
@@ -6,7 +6,7 @@ class ConformFtrack(pyblish.api.InstancePlugin):
     """ Creating components in Ftrack. """
 
     order = pyblish.api.IntegratorOrder + 0.4
-    label = "Ftrack"
+    label = "Conform Ftrack"
 
     def process(self, instance):
 

--- a/pyblish_ftrack/plugins/extract_ftrack.py
+++ b/pyblish_ftrack/plugins/extract_ftrack.py
@@ -8,7 +8,7 @@ class ExtractFtrack(pyblish.api.Extractor):
     """ Creating any Asset or AssetVersion in Ftrack.
     """
 
-    label = 'Ftrack'
+    label = 'Extract Ftrack'
 
     def process(self, instance, context):
 

--- a/pyblish_ftrack/plugins/integrate_ftrack_api.py
+++ b/pyblish_ftrack/plugins/integrate_ftrack_api.py
@@ -8,7 +8,7 @@ class IntegrateFtrackApi(pyblish.api.InstancePlugin):
     """ Commit components to server. """
 
     order = pyblish.api.IntegratorOrder
-    label = "Ftrack"
+    label = "Integrate Ftrack Api"
     families = ["ftrack"]
 
     def query(self, entitytype, data):

--- a/pyblish_ftrack/plugins/integrate_ftrack_api.py
+++ b/pyblish_ftrack/plugins/integrate_ftrack_api.py
@@ -4,7 +4,7 @@ import pyblish.api
 import clique
 
 
-class PyblishFtrackIntegrateFtrackApi(pyblish.api.InstancePlugin):
+class IntegrateFtrackApi(pyblish.api.InstancePlugin):
     """ Commit components to server. """
 
     order = pyblish.api.IntegratorOrder

--- a/pyblish_ftrack/plugins/validate_ftrack.py
+++ b/pyblish_ftrack/plugins/validate_ftrack.py
@@ -10,7 +10,7 @@ class ValidateFtrack(pyblish.api.Validator):
 
     order = pyblish.api.Validator.order + 0.1
     optional = True
-    label = 'Ftrack'
+    label = 'Validate Ftrack'
 
     def process(self, instance, context):
 


### PR DESCRIPTION
**Motivation**

It is often difficult to debug program flow due to labels all being set to "Ftrack". 

**What's changed**

This makes each plugin label unique, allowing a user to easily identify which plugin might be running slow. Additionally, the classes have been renamed to follow the same pattern and match the names of classes within.